### PR TITLE
fix(payments): add missing CPO receiver endpoints for OCPI 2.3.0

### DIFF
--- a/ocpi/modules/payments/v_2_3_0/api/cpo.py
+++ b/ocpi/modules/payments/v_2_3_0/api/cpo.py
@@ -1,10 +1,18 @@
 """CPO API for payments module - OCPI 2.3.0.
 
 New in OCPI 2.3.0 - Payment terminal support.
-The CPO receives terminal information from PTP and assigns locations/EVSEs.
+
+The CPO is the Receiver for the Payments module. It receives terminal
+information and financial advice confirmations from the PTP.
+
+Receiver interface (CPO):
+  Terminals              - GET list, GET by ID, PUT, PATCH
+  FinancialAdvice        - GET list, GET by ID, PUT
+
+Reference: https://github.com/ocpi/ocpi/blob/release-2.3.0-bugfixes/mod_payments.asciidoc
 """
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 
 from ocpi.core import status
 from ocpi.core.adapter import Adapter
@@ -12,12 +20,13 @@ from ocpi.core.authentication.verifier import AuthorizationVerifier
 from ocpi.core.config import logger
 from ocpi.core.crud import Crud
 from ocpi.core.data_types import CiString
-from ocpi.core.dependencies import get_adapter, get_crud
+from ocpi.core.dependencies import get_adapter, get_crud, pagination_filters
 from ocpi.core.enums import ModuleID, RoleEnum
 from ocpi.core.exceptions import NotFoundOCPIError
 from ocpi.core.schemas import OCPIResponse
-from ocpi.core.utils import get_auth_token
+from ocpi.core.utils import get_auth_token, get_list
 from ocpi.modules.payments.v_2_3_0.schemas import (
+    FinancialAdviceConfirmation,
     Terminal,
     TerminalPartialUpdate,
 )
@@ -27,6 +36,60 @@ router = APIRouter(
     prefix="/payments",
     dependencies=[Depends(AuthorizationVerifier(VersionNumber.v_2_3_0))],
 )
+
+
+# ---------------------------------------------------------------------------
+# Terminal endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/terminals", response_model=OCPIResponse)
+async def get_terminals(
+    request: Request,
+    response: Response,
+    crud: Crud = Depends(get_crud),
+    adapter: Adapter = Depends(get_adapter),
+    filters: dict = Depends(pagination_filters),
+):
+    """
+    Get terminals.
+
+    Retrieves a list of terminals known to this CPO.
+
+    **Query parameters:**
+        - limit (int): Maximum number of objects to GET (default=50).
+        - offset (int): The offset of the first object returned (default=0).
+        - date_from (datetime): Only return Terminals that have
+            last_updated after this Date/Time (default=None).
+        - date_to (datetime): Only return Terminals that have
+            last_updated before this Date/Time (default=None).
+
+    **Returns:**
+        The OCPIResponse containing the list of terminals.
+    """
+    logger.info("Received request to get terminals (CPO).")
+    auth_token = get_auth_token(request)
+
+    data_list = await get_list(
+        response,
+        filters,
+        ModuleID.payments,
+        RoleEnum.cpo,
+        VersionNumber.v_2_3_0,
+        crud,
+        auth_token=auth_token,
+    )
+
+    terminals = []
+    for data in data_list:
+        terminals.append(
+            adapter.terminal_adapter(data, VersionNumber.v_2_3_0).model_dump()
+        )
+    logger.debug(f"Amount of terminals in response: {len(terminals)}")
+    return OCPIResponse(
+        data=terminals,
+        **status.OCPI_1000_GENERIC_SUCESS_CODE,
+    )
 
 
 @router.get("/terminals/{terminal_id}", response_model=OCPIResponse)
@@ -76,6 +139,8 @@ async def put_terminal(
 ):
     """
     Create or update a terminal.
+
+    Called by the PTP to push terminal data to the CPO.
 
     **Path parameters:**
         - terminal_id (str): The ID of the terminal.
@@ -138,5 +203,153 @@ async def patch_terminal(
     )
     return OCPIResponse(
         data=[adapter.terminal_adapter(data, VersionNumber.v_2_3_0).model_dump()],
+        **status.OCPI_1000_GENERIC_SUCESS_CODE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Financial Advice Confirmation endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/financial-advice-confirmations", response_model=OCPIResponse)
+async def get_financial_advice_confirmations(
+    request: Request,
+    response: Response,
+    crud: Crud = Depends(get_crud),
+    adapter: Adapter = Depends(get_adapter),
+    filters: dict = Depends(pagination_filters),
+):
+    """
+    Get financial advice confirmations.
+
+    Retrieves a list of financial advice confirmations received by this CPO.
+
+    **Query parameters:**
+        - limit (int): Maximum number of objects to GET.
+        - offset (int): The offset of the first object returned.
+        - date_from (datetime): Filter by last_updated after this time.
+        - date_to (datetime): Filter by last_updated before this time.
+
+    **Returns:**
+        The OCPIResponse containing the list of confirmations.
+    """
+    logger.info("Received request to get financial advice confirmations (CPO).")
+    auth_token = get_auth_token(request)
+
+    data_list = await get_list(
+        response,
+        filters,
+        ModuleID.payments,
+        RoleEnum.cpo,
+        VersionNumber.v_2_3_0,
+        crud,
+        auth_token=auth_token,
+        object_type="financial_advice_confirmation",
+    )
+
+    confirmations = []
+    for data in data_list:
+        confirmations.append(
+            adapter.financial_advice_confirmation_adapter(
+                data, VersionNumber.v_2_3_0
+            ).model_dump()
+        )
+    return OCPIResponse(
+        data=confirmations,
+        **status.OCPI_1000_GENERIC_SUCESS_CODE,
+    )
+
+
+@router.get(
+    "/financial-advice-confirmations/{confirmation_id}",
+    response_model=OCPIResponse,
+)
+async def get_financial_advice_confirmation(
+    request: Request,
+    confirmation_id: CiString(36),  # type: ignore
+    crud: Crud = Depends(get_crud),
+    adapter: Adapter = Depends(get_adapter),
+):
+    """
+    Get financial advice confirmation by ID.
+
+    **Path parameters:**
+        - confirmation_id (str): The ID of the confirmation.
+
+    **Returns:**
+        The OCPIResponse containing the confirmation details.
+    """
+    logger.info(
+        f"Received request to get financial advice confirmation - `{confirmation_id}`."
+    )
+    auth_token = get_auth_token(request)
+
+    data = await crud.get(
+        ModuleID.payments,
+        RoleEnum.cpo,
+        confirmation_id,
+        auth_token=auth_token,
+        version=VersionNumber.v_2_3_0,
+        object_type="financial_advice_confirmation",
+    )
+    if data:
+        return OCPIResponse(
+            data=[
+                adapter.financial_advice_confirmation_adapter(
+                    data, VersionNumber.v_2_3_0
+                ).model_dump()
+            ],
+            **status.OCPI_1000_GENERIC_SUCESS_CODE,
+        )
+    raise NotFoundOCPIError
+
+
+@router.put(
+    "/financial-advice-confirmations/{confirmation_id}",
+    response_model=OCPIResponse,
+)
+async def put_financial_advice_confirmation(
+    request: Request,
+    confirmation_id: CiString(36),  # type: ignore
+    confirmation: FinancialAdviceConfirmation,
+    crud: Crud = Depends(get_crud),
+    adapter: Adapter = Depends(get_adapter),
+):
+    """
+    Create or update a financial advice confirmation.
+
+    Called by the PTP to push a financial advice confirmation to the CPO
+    after a payment transaction is completed at a terminal.
+
+    **Path parameters:**
+        - confirmation_id (str): The ID of the confirmation.
+
+    **Request body:**
+        - confirmation (FinancialAdviceConfirmation): The confirmation object.
+
+    **Returns:**
+        The OCPIResponse containing the confirmation details.
+    """
+    logger.info(
+        f"Received request to put financial advice confirmation - `{confirmation_id}`."
+    )
+    auth_token = get_auth_token(request)
+
+    data = await crud.update(
+        ModuleID.payments,
+        RoleEnum.cpo,
+        confirmation.model_dump(),
+        confirmation_id,
+        auth_token=auth_token,
+        version=VersionNumber.v_2_3_0,
+        object_type="financial_advice_confirmation",
+    )
+    return OCPIResponse(
+        data=[
+            adapter.financial_advice_confirmation_adapter(
+                data, VersionNumber.v_2_3_0
+            ).model_dump()
+        ],
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )


### PR DESCRIPTION
## Summary

The CPO Receiver interface for the Payments module (OCPI 2.3.0) was incomplete. It only exposed individual terminal operations (GET/PUT/PATCH by ID), but was missing the endpoints needed for a PTP to push financial advice confirmations and for the CPO to list its own data.

**Added endpoints:**
- `GET /payments/terminals` — list terminals known to the CPO
- `GET /payments/financial-advice-confirmations` — list financial advice confirmations
- `GET /payments/financial-advice-confirmations/{id}` — get confirmation by ID
- `PUT /payments/financial-advice-confirmations/{id}` — receive confirmation from PTP

**Reference:** [mod_payments.asciidoc](https://github.com/ocpi/ocpi/blob/release-2.3.0-bugfixes/mod_payments.asciidoc)

## Test plan
- [x] All 417 existing tests pass
- [x] Routes load correctly (verified 7 CPO payment routes)
- [ ] Integration test with PTP pushing financial advice to CPO


Made with [Cursor](https://cursor.com)