### PR TITLE
fix: add default None to optional command schema fields

### DIFF
--- a/ocpi/modules/commands/v_2_1_1/schemas.py
+++ b/ocpi/modules/commands/v_2_1_1/schemas.py
@@ -23,7 +23,7 @@ class ReserveNow(BaseModel):
     expiry_date: DateTime
     reservation_id: int
     location_id: String(36)  # type: ignore
-    evse_uid: String(39) | None  # type: ignore
+    evse_uid: String(39) | None = None  # type: ignore
 
 
 class StartSession(BaseModel):
@@ -34,7 +34,7 @@ class StartSession(BaseModel):
     response_url: URL
     token: Token
     location_id: String(39)  # type: ignore
-    evse_uid: String(39) | None  # type: ignore
+    evse_uid: String(39) | None = None  # type: ignore
 
 
 class StopSession(BaseModel):

--- a/ocpi/modules/commands/v_2_2_1/schemas.py
+++ b/ocpi/modules/commands/v_2_2_1/schemas.py
@@ -46,8 +46,8 @@ class ReserveNow(BaseModel):
     expiry_date: DateTime
     reservation_id: CiString(36)  # type: ignore
     location_id: CiString(36)  # type: ignore
-    evse_uid: CiString(36) | None  # type: ignore
-    authorization_reference: CiString(36) | None  # type: ignore
+    evse_uid: CiString(36) | None = None  # type: ignore
+    authorization_reference: CiString(36) | None = None  # type: ignore
 
 
 class StartSession(BaseModel):
@@ -58,9 +58,9 @@ class StartSession(BaseModel):
     response_url: URL
     token: Token
     location_id: CiString(36)  # type: ignore
-    evse_uid: CiString(36) | None  # type: ignore
-    connector_id: CiString(36) | None  # type: ignore
-    authorization_reference: CiString(36) | None  # type: ignore
+    evse_uid: CiString(36) | None = None  # type: ignore
+    connector_id: CiString(36) | None = None  # type: ignore
+    authorization_reference: CiString(36) | None = None  # type: ignore
 
 
 class StopSession(BaseModel):

--- a/ocpi/modules/commands/v_2_3_0/schemas.py
+++ b/ocpi/modules/commands/v_2_3_0/schemas.py
@@ -46,8 +46,8 @@ class ReserveNow(BaseModel):
     expiry_date: DateTime
     reservation_id: CiString(36)  # type: ignore
     location_id: CiString(36)  # type: ignore
-    evse_uid: CiString(36) | None  # type: ignore
-    authorization_reference: CiString(36) | None  # type: ignore
+    evse_uid: CiString(36) | None = None  # type: ignore
+    authorization_reference: CiString(36) | None = None  # type: ignore
 
 
 class StartSession(BaseModel):
@@ -58,9 +58,9 @@ class StartSession(BaseModel):
     response_url: URL
     token: Token
     location_id: CiString(36)  # type: ignore
-    evse_uid: CiString(36) | None  # type: ignore
-    connector_id: CiString(36) | None  # type: ignore
-    authorization_reference: CiString(36) | None  # type: ignore
+    evse_uid: CiString(36) | None = None  # type: ignore
+    connector_id: CiString(36) | None = None  # type: ignore
+    authorization_reference: CiString(36) | None = None  # type: ignore
 
 
 class StopSession(BaseModel):


### PR DESCRIPTION
## Summary
- Adds `= None` default to all optional (`| None`) fields in `StartSession`, `ReserveNow` command schemas across OCPI versions 2.1.1, 2.2.1, and 2.3.0
- Without the default, Pydantic v2 treats `X | None` as "required but nullable", causing 422 validation errors when callers correctly omit optional fields per OCPI spec (cardinality `?`)
- This was triggered by Payter sending a `START_SESSION` without `connector_id`, which is valid per spec but rejected by our schema

## Test plan
- [x] All 296 existing tests pass
- [ ] Verify Payter can send START_SESSION without `connector_id` and get a valid response


Made with [Cursor](https://cursor.com)