### PR TITLE
feat: add SCSP role (sessions + chargingprofiles receiver)

### DIFF
--- a/ocpi/core/routers/v_2_2_1/__init__.py
+++ b/ocpi/core/routers/v_2_2_1/__init__.py
@@ -1,8 +1,13 @@
 from ocpi.modules.versions import versions_v_2_2_1_router
-from ocpi.routers import v_2_2_1_cpo_router, v_2_2_1_emsp_router
+from ocpi.routers import (
+    v_2_2_1_cpo_router,
+    v_2_2_1_emsp_router,
+    v_2_2_1_scsp_router,
+)
 
 ROUTERS_DICT = {
     "version_router": versions_v_2_2_1_router,
     "cpo_router": v_2_2_1_cpo_router,
     "emsp_router": v_2_2_1_emsp_router,
+    "scsp_router": v_2_2_1_scsp_router,
 }

--- a/ocpi/main.py
+++ b/ocpi/main.py
@@ -271,6 +271,16 @@ def get_application(
                         tags=[f"PTP {version.value}"],
                     )
 
+        if RoleEnum.scsp in roles:
+            for module in modules:
+                scsp_router = mapped_version.get("scsp_router", {}).get(module)  # type: ignore[attr-defined]
+                if scsp_router:
+                    _app.include_router(
+                        scsp_router,  # type: ignore[arg-type]
+                        prefix=f"/{settings.OCPI_PREFIX}/scsp/{version.value}",
+                        tags=[f"SCSP {version.value}"],
+                    )
+
     def override_get_crud():
         return crud
 

--- a/ocpi/routers/__init__.py
+++ b/ocpi/routers/__init__.py
@@ -2,6 +2,7 @@ from .v_2_1_1.cpo import router as v_2_1_1_cpo_router
 from .v_2_1_1.emsp import router as v_2_1_1_emsp_router
 from .v_2_2_1.cpo import router as v_2_2_1_cpo_router
 from .v_2_2_1.emsp import router as v_2_2_1_emsp_router
+from .v_2_2_1.scsp import router as v_2_2_1_scsp_router
 from .v_2_3_0.cpo import router as v_2_3_0_cpo_router
 from .v_2_3_0.emsp import router as v_2_3_0_emsp_router
 from .v_2_3_0.ptp import router as v_2_3_0_ptp_router

--- a/ocpi/routers/v_2_2_1/scsp.py
+++ b/ocpi/routers/v_2_2_1/scsp.py
@@ -1,0 +1,20 @@
+"""SCSP routers for OCPI 2.2.1.
+
+The SCSP (Smart Charging Service Provider) is a *receiver* of Sessions and
+ChargingProfiles, so it reuses the eMSP receiver-side module routers (the
+receiver interface is identical). Mounted under the ``/scsp/`` prefix by
+``get_application``.
+"""
+
+from ocpi.core.enums import ModuleID
+from ocpi.modules.chargingprofiles.v_2_2_1.api import (
+    emsp_router as chargingprofiles_emsp_2_2_1_router,
+)
+from ocpi.modules.sessions.v_2_2_1.api import (
+    emsp_router as sessions_emsp_2_2_1_router,
+)
+
+router = {
+    ModuleID.sessions: sessions_emsp_2_2_1_router,
+    ModuleID.charging_profile: chargingprofiles_emsp_2_2_1_router,
+}


### PR DESCRIPTION
Adds the **SCSP** (Smart Charging Service Provider) role. It reuses the existing eMSP receiver-side module routers and `get_application` mounts them under the `/scsp/` prefix when `RoleEnum.scsp` is enabled — e.g. `/ocpi/scsp/2.2.1/sessions/{country_code}/{party_id}/{session_id}`.

Mirrors the PTP role wiring; no behaviour change for existing roles. Enables the elu-charge SMATRICS SCSP sessions integration.

> No `development` branch in this repo → targeted `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)