### PR TITLE
fix(2.2.1): make optional Session/ChargingPeriod fields omittable

### DIFF
--- a/ocpi/modules/cdrs/v_2_2_1/schemas.py
+++ b/ocpi/modules/cdrs/v_2_2_1/schemas.py
@@ -50,7 +50,9 @@ class ChargingPeriod(BaseModel):
 
     start_date_time: DateTime
     dimensions: list[CdrDimension]
-    tariff_id: CiString(36) | None  # type: ignore
+    # Optional per spec: allow it to be omitted entirely (not just null), so a CPO
+    # that doesn't send tariff_id doesn't trigger a 422.
+    tariff_id: CiString(36) | None = None  # type: ignore
 
 
 class CdrToken(BaseModel):

--- a/ocpi/modules/sessions/v_2_2_1/api/cpo.py
+++ b/ocpi/modules/sessions/v_2_2_1/api/cpo.py
@@ -58,7 +58,7 @@ async def get_sessions(
 
     sessions = []
     for data in data_list:
-        sessions.append(adapter.session_adapter(data).model_dump())
+        sessions.append(adapter.session_adapter(data, VersionNumber.v_2_2_1).model_dump())
     logger.debug(f"Amount of sessions in response: {len(sessions)}")
     return OCPIResponse(
         data=sessions,

--- a/ocpi/modules/sessions/v_2_2_1/api/emsp.py
+++ b/ocpi/modules/sessions/v_2_2_1/api/emsp.py
@@ -135,7 +135,7 @@ async def add_or_update_session(
         )
 
     return OCPIResponse(
-        data=[adapter.session_adapter(data).model_dump()],
+        data=[adapter.session_adapter(data, VersionNumber.v_2_2_1).model_dump()],
         **status.OCPI_1000_GENERIC_SUCESS_CODE,
     )
 
@@ -185,7 +185,10 @@ async def partial_update_session(
         version=VersionNumber.v_2_2_1,
     )
     if old_data:
-        old_session = adapter.session_adapter(old_data)
+        # Adapt with this receiver's version (2.2.1); the default is the latest
+        # version, which would re-validate the stored session against a newer,
+        # stricter schema and 500 on fields optional in 2.2.1.
+        old_session = adapter.session_adapter(old_data, version=VersionNumber.v_2_2_1)
 
         new_session = copy.deepcopy(old_session)
         partially_update_attributes(
@@ -204,7 +207,7 @@ async def partial_update_session(
         )
 
         return OCPIResponse(
-            data=[adapter.session_adapter(data).model_dump()],
+            data=[adapter.session_adapter(data, VersionNumber.v_2_2_1).model_dump()],
             **status.OCPI_1000_GENERIC_SUCESS_CODE,
         )
     logger.debug(f"Session with id `{session_id}` was not found.")

--- a/ocpi/modules/sessions/v_2_2_1/schemas.py
+++ b/ocpi/modules/sessions/v_2_2_1/schemas.py
@@ -15,18 +15,18 @@ class Session(BaseModel):
     party_id: CiString(3)  # type: ignore
     id: CiString(36)  # type: ignore
     start_date_time: DateTime
-    end_date_time: DateTime | None
+    end_date_time: DateTime | None = None
     kwh: Number
     cdr_token: CdrToken
     auth_method: AuthMethod
-    authorization_reference: CiString(36) | None  # type: ignore
+    authorization_reference: CiString(36) | None = None  # type: ignore
     location_id: CiString(36)  # type: ignore
     evse_uid: CiString(36)  # type: ignore
     connector_id: CiString(36)  # type: ignore
-    meter_id: String(255) | None  # type: ignore
+    meter_id: String(255) | None = None  # type: ignore
     currency: String(3)  # type: ignore
     charging_periods: list[ChargingPeriod] = []
-    total_cost: Price | None
+    total_cost: Price | None = None
     status: SessionStatus
     last_updated: DateTime
 


### PR DESCRIPTION
Several OCPI 2.2.1 fields were declared `X | None` **without a default**, which in Pydantic v2 makes them *required-but-nullable* — a counterparty that **omits** the field entirely (rather than sending `null`) gets a **422**.

Observed live: SMATRICS pushes Sessions whose `charging_periods[]` omit `tariff_id` → every PUT/PATCH to our sessions receiver returned `422 Unprocessable Entity`.

## Fix
Add `= None` defaults so these can be omitted:
- `ChargingPeriod.tariff_id`
- `Session.end_date_time`, `Session.authorization_reference`, `Session.meter_id`, `Session.total_cost`

All are optional per the OCPI 2.2.1 spec. Verified: a PATCH with `charging_periods` missing `tariff_id`, and a full PUT omitting these optionals, both validate now (deployed to dev — pushes that were 422 now return 200 and persist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)